### PR TITLE
Code clean up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,50 @@
+*.py[cod]
+
+# C extensions
+*.so
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+htmlcov
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Complexity
+output/*.html
+output/*/index.html
+
+# Sphinx
+docs/_build
+
+# Mac
+.DS_Store
+._*
+
+# PyCharm
+.idea/

--- a/theoldreader.py
+++ b/theoldreader.py
@@ -1,321 +1,208 @@
 __author__ = 'Qra'
 
 import urllib.request
-import urllib.request
 import urllib.parse
 import json
+import logging
+logger = logging.getLogger(__name__)
+
+url_api = 'https://theoldreader.com/reader/api/0/'
+url_login = 'https://theoldreader.com/accounts/ClientLogin'
+
+
+def make_request(url, var, header={}, use_get=True):
+    var_json = {'output': 'json'}
+    var_json.update(var)
+    encoded = urllib.parse.urlencode(var_json)
+    data = None
+    if use_get:
+        url = url + '?' + encoded
+    else:
+        data = encoded.encode('utf-8')  # data should be bytes
+    req = urllib.request.Request(url, data=data, headers=header)
+    response = urllib.request.urlopen(req)
+    the_page = response.read()
+    return json.loads(the_page.decode("utf-8"))
 
 
 class TheOldReaderConnection(object):
-	def __init__(self, client, email, password):
-		url = 'https://theoldreader.com/accounts/ClientLogin'
-		var = {
-			'client': client,
-			'accountType': 'HOSTED_OR_GOOGLE',
-			'service': 'reader',
-			'Email': email,
-			'Passwd': password,
-			'output': 'json'
-		}
-		data = urllib.parse.urlencode(var)
-		data = data.encode('utf-8')  # data should be bytes
-		req = urllib.request.Request(url, data)
-		response = urllib.request.urlopen(req)
-		the_page = response.read()
-		resp1 = json.loads(the_page.decode("utf-8"))
-		self.auth_code = resp1['Auth']
-		self.header = {'Authorization': "GoogleLogin auth=" + self.auth_code}
+    def __init__(self, client, email, password):
+        var = {
+            'client': client,
+            'accountType': 'HOSTED_OR_GOOGLE',
+            'service': 'reader',
+            'Email': email,
+            'Passwd': password
+        }
+        resp1 = make_request(url_login, var, use_get=False)
+        self.auth_code = resp1['Auth']
+        self.header = {'Authorization': "GoogleLogin auth=" + self.auth_code}
 
 
 class TheOldReaderItem(object):
-	def __init__(self, header, item_id):
-		self.item_id = item_id
-		self.header = header
-		self.title = None
-		self.content = None
-		self.href = None
 
-	# Mark as read
-	def mark_as_read(self):
-		url = 'https://theoldreader.com/reader/api/0/edit-tag'
-		var = {
-			'a': 'user/-/state/com.google/read',
-			'i': self.item_id
-		}
-		data = urllib.parse.urlencode(var)
-		data = data.encode('utf-8')  # data should be bytes
-		req = urllib.request.Request(url, data=data, headers=self.header)
-		response = urllib.request.urlopen(req)
-		the_page = response.read()
-		print(the_page)
+    def __init__(self, connection, item_id):
+        """
+        Initialize object
 
-	# Mark as unread
-	def mark_as_unread(self):
-		url = 'https://theoldreader.com/reader/api/0/edit-tag'
-		var = {
-			'r': 'user/-/state/com.google/read',
-			'i': self.item_id
-		}
-		data = urllib.parse.urlencode(var)
-		data = data.encode('utf-8')  # data should be bytes
-		req = urllib.request.Request(url, data=data, headers=self.header)
-		response = urllib.request.urlopen(req)
-		the_page = response.read()
-		print(the_page)
+        :param connection: The corresponding connection
+        :type connection: TheOldReaderConnection
+        :param item_id: Id of item
+        :type item_id: str
+        :rtype: None
+        """
+        self.item_id = item_id
+        self.connection = connection
+        self.title = None
+        self.content = None
+        self.href = None
 
-	# Mark as starred
-	def mark_as_starred(self):
-		url = 'https://theoldreader.com/reader/api/0/edit-tag'
-		var = {
-			'a': 'user/-/state/com.google/starred',
-			'i': self.item_id
-		}
-		data = urllib.parse.urlencode(var)
-		data = data.encode('utf-8')  # data should be bytes
-		req = urllib.request.Request(url, data=data, headers=self.header)
-		response = urllib.request.urlopen(req)
-		the_page = response.read()
-		print(the_page)
+    def _make_api_request(self, url_end, var):
+        return make_request(url_api + url_end, var, self.connection.header)
 
-	# remove_starred_mark
-	def remove_starred_mark(self):
-		url = 'https://theoldreader.com/reader/api/0/edit-tag'
-		var = {
-			'r': 'user/-/state/com.google/starred',
-			'i': self.item_id
-		}
-		data = urllib.parse.urlencode(var)
-		data = data.encode('utf-8')  # data should be bytes
-		req = urllib.request.Request(url, data=data, headers=self.header)
-		response = urllib.request.urlopen(req)
-		the_page = response.read()
-		print(the_page)
+    def _make_edit_request(self, state, undo=False, additional_var=None):
+        """
+        Make request to api for this item
 
-	# Mark as liked
-	def mark_as_liked(self):
-		url = 'https://theoldreader.com/reader/api/0/edit-tag'
-		var = {
-			'a': 'user/-/state/com.google/like',
-			'i': self.item_id
-		}
-		data = urllib.parse.urlencode(var)
-		data = data.encode('utf-8')  # data should be bytes
-		req = urllib.request.Request(url, data=data, headers=self.header)
-		response = urllib.request.urlopen(req)
-		the_page = response.read()
-		print(the_page)
+        :param state: Which attribute to change (read, starred, like, ..)
+        :type state: str
+        :param undo: If true, undos the state (Unread, remove starred, ..)
+            (default: False)
+        :type undo: bool
+        :param additional_var: Add aditional fields to url params
+        :type additional_var: None | dict
+        :return: Response of urlopen
+        :rtype: None | int | float | str | list | dict
+        """
+        var = {
+            'a': 'user/-/state/com.google/' + state
+        }
 
-	# remove_liked_mark
-	def remove_liked_mark(self):
-		url = 'https://theoldreader.com/reader/api/0/edit-tag'
-		var = {
-			'r': 'user/-/state/com.google/like',
-			'i': self.item_id
-		}
-		data = urllib.parse.urlencode(var)
-		data = data.encode('utf-8')  # data should be bytes
-		req = urllib.request.Request(url, data=data, headers=self.header)
-		response = urllib.request.urlopen(req)
-		the_page = response.read()
-		print(the_page)
+        if undo:
+            var['r'] = 'user/-/state/com.google/' + state
+        else:
+            var['a'] = 'user/-/state/com.google/' + state
+        if additional_var:
+            var.update(additional_var)
+        return self._make_api_request('edit-tag', var)
 
-	# Mark as shared
-	def mark_as_shared(self):
-		url = 'https://theoldreader.com/reader/api/0/edit-tag'
-		var = {
-			'a': 'user/-/state/com.google/broadcast',
-			'i': self.item_id
-		}
-		data = urllib.parse.urlencode(var)
-		data = data.encode('utf-8')  # data should be bytes
-		req = urllib.request.Request(url, data=data, headers=self.header)
-		response = urllib.request.urlopen(req)
-		the_page = response.read()
-		print(the_page)
+    # Mark as read
+    def mark_as_read(self):
+        return self._make_edit_request('read')
 
-	# Mark as shared (with_note)
-	def mark_as_shared_with_note(self, note):
-		url = 'https://theoldreader.com/reader/api/0/edit-tag'
-		var = {
-			'a': 'user/-/state/com.google/broadcast',
-			'annotation': note,
-			'i': self.item_id
-		}
-		data = urllib.parse.urlencode(var)
-		data = data.encode('utf-8')  # data should be bytes
-		req = urllib.request.Request(url, data=data, headers=self.header)
-		response = urllib.request.urlopen(req)
-		the_page = response.read()
-		print(the_page)
+    # Mark as unread
+    def mark_as_unread(self):
+        return self._make_edit_request('read', True)
 
-	# remove_shared_mark
-	def remove_shared_mark(self):
-		url = 'https://theoldreader.com/reader/api/0/edit-tag'
-		var = {
-			'r': 'user/-/state/com.google/broadcast',
-			'i': self.item_id
-		}
-		data = urllib.parse.urlencode(var)
-		data = data.encode('utf-8')  # data should be bytes
-		req = urllib.request.Request(url, data=data, headers=self.header)
-		response = urllib.request.urlopen(req)
-		the_page = response.read()
-		print(the_page)
+    # Mark as starred
+    def mark_as_starred(self):
+        return self._make_edit_request('starred')
 
-	# get more information(title, description, link)
-	def get_details(self):
-		url = 'https://theoldreader.com/reader/api/0/stream/items/contents?output=json&i='
-		req = urllib.request.Request(url + self.item_id, data=None, headers=self.header)
-		response = urllib.request.urlopen(req)
-		the_page = response.read()
-		resp3 = json.loads(the_page.decode("utf-8"))
-		item_det = resp3['items'][0]
-		self.title = item_det['title']
-		self.content = item_det['summary']['content']
-		self.href = item_det['alternate'][0]['href']
+    # remove_starred_mark
+    def remove_starred_mark(self):
+        return self._make_edit_request('starred', True)
+
+    # Mark as liked
+    def mark_as_liked(self):
+        return self._make_edit_request('like')
+
+    # remove_liked_mark
+    def remove_liked_mark(self):
+        return self._make_edit_request('like', True)
+
+    # Mark as shared
+    def mark_as_shared(self):
+        return self._make_edit_request('broadcast')
+
+    # Mark as shared (with_note)
+    def mark_as_shared_with_note(self, note):
+        return self._make_edit_request(
+            'broadcast',
+            additional_var={'annotation': note}
+        )
+
+    # remove_shared_mark
+    def remove_shared_mark(self):
+        return self._make_edit_request('broadcast', True)
+
+    # get more information(title, description, link)
+    def get_details(self):
+        resp3 = self._make_api_request(
+            'stream/items/contents',
+            {'i': self.item_id}
+        )
+        item_det = resp3['items'][0]
+        self.title = item_det['title']
+        self.content = item_det['summary']['content']
+        self.href = item_det['alternate'][0]['href']
 
 
 class TheOldReaderItemsSearch(object):
-	def __init__(self, header):
-		self.header = header
+    def __init__(self, connection):
+        """
+        Initialize object
 
-	def get_unread_only(self):
-		url = 'https://theoldreader.com/reader/api/0/stream/items/ids'
-		var = {
-			'output': 'json',
-			's': 'user/-/state/com.google/reading-list',
-			'xt': 'user/-/state/com.google/read',
-			'n': 100
-		}
-		data = urllib.parse.urlencode(var)
-		req = urllib.request.Request(url + '?' + data, data=None, headers=self.header)
-		response = urllib.request.urlopen(req)
-		the_page = response.read()
-		resp = json.loads(the_page.decode("utf-8"))
-		continuation = resp.get('continuation')
-		items_list = []
-		items_list = items_list + resp['itemRefs']
-		while continuation is not None:
-			var = {
-				'output': 'json',
-				's': 'user/-/state/com.google/reading-list',
-				'xt': 'user/-/state/com.google/read',
-				'n': 100,
-				'c': continuation
-			}
-			data = urllib.parse.urlencode(var)
-			req = urllib.request.Request(url + '?' + data, data=None, headers=self.header)
-			response = urllib.request.urlopen(req)
-			the_page = response.read()
-			resp = json.loads(the_page.decode("utf-8"))
-			continuation = resp.get('continuation')
-			items_list = items_list + resp['itemRefs']
-		obj_item_list = []
-		for item in items_list:
-			obj_item_list.append(TheOldReaderItem(self.header, item.get('id')))
-		return obj_item_list
+        :param connection: The corresponding connection
+        :type connection: TheOldReaderConnection
+        :rtype: None
+        """
+        self.connection = connection
 
-	def get_starred_only(self):
-		url = 'https://theoldreader.com/reader/api/0/stream/items/ids'
-		var = {
-			'output': 'json',
-			's': 'user/-/state/com.google/starred',
-			'n': 100
-		}
-		data = urllib.parse.urlencode(var)
-		req = urllib.request.Request(url + '?' + data, data=None, headers=self.header)
-		response = urllib.request.urlopen(req)
-		the_page = response.read()
-		resp = json.loads(the_page.decode("utf-8"))
-		continuation = resp.get('continuation')
-		items_list = []
-		items_list = items_list + resp['itemRefs']
-		while continuation is not None:
-			var = {
-				'output': 'json',
-				's': 'user/-/state/com.google/reading-list',
-				'xt': 'user/-/state/com.google/read',
-				'n': 100,
-				'c': continuation
-			}
-			data = urllib.parse.urlencode(var)
-			req = urllib.request.Request(url + '?' + data, data=None, headers=self.header)
-			response = urllib.request.urlopen(req)
-			the_page = response.read()
-			resp = json.loads(the_page.decode("utf-8"))
-			continuation = resp.get('continuation')
-			items_list = items_list + resp['itemRefs']
-		obj_item_list = []
-		for item in items_list:
-			obj_item_list.append(TheOldReaderItem(self.header, item.get('id')))
-		return obj_item_list
+    def _make_search_request(self, var, limit_items=1000):
+        var['n'] = limit_items
+        return make_request(
+            url_api + 'stream/items/ids',
+            var,
+            self.connection.header,
+            True
+        )
 
-	def get_liked_only(self):
-		url = 'https://theoldreader.com/reader/api/0/stream/items/ids'
-		var = {
-			'output': 'json',
-			's': 'user/-/state/com.google/like',
-			'n': 100
-		}
-		data = urllib.parse.urlencode(var)
-		req = urllib.request.Request(url + '?' + data, data=None, headers=self.header)
-		response = urllib.request.urlopen(req)
-		the_page = response.read()
-		resp = json.loads(the_page.decode("utf-8"))
-		continuation = resp.get('continuation')
-		items_list = []
-		items_list = items_list + resp['itemRefs']
-		while continuation is not None:
-			var = {
-				'output': 'json',
-				's': 'user/-/state/com.google/reading-list',
-				'xt': 'user/-/state/com.google/read',
-				'n': 100,
-				'c': continuation
-			}
-			data = urllib.parse.urlencode(var)
-			req = urllib.request.Request(url + '?' + data, data=None, headers=self.header)
-			response = urllib.request.urlopen(req)
-			the_page = response.read()
-			resp = json.loads(the_page.decode("utf-8"))
-			continuation = resp.get('continuation')
-			items_list = items_list + resp['itemRefs']
-		obj_item_list = []
-		for item in items_list:
-			obj_item_list.append(TheOldReaderItem(self.header, item.get('id')))
-		return obj_item_list
+    def _load_rest(self, continuation, var, limit_items=1000, items_list=None):
+        if items_list is None:
+            items_list = []
+        while continuation is not None:
+            var['c'] = continuation
+            resp = self._make_search_request(var, limit_items)
+            continuation = resp.get('continuation')
+            items_list.extend(resp['itemRefs'])
+        return [
+            TheOldReaderItem(self.connection, item.get('id'))
+            for item in items_list
+        ]
 
-	def get_shared_only(self):
-		url = 'https://theoldreader.com/reader/api/0/stream/items/ids'
-		var = {
-			'output': 'json',
-			's': 'user/-/state/com.google/broadcast',
-			'n': 100
-		}
-		data = urllib.parse.urlencode(var)
-		req = urllib.request.Request(url + '?' + data, data=None, headers=self.header)
-		response = urllib.request.urlopen(req)
-		the_page = response.read()
-		resp = json.loads(the_page.decode("utf-8"))
-		continuation = resp.get('continuation')
-		items_list = []
-		items_list = items_list + resp['itemRefs']
-		while continuation is not None:
-			var = {
-				'output': 'json',
-				's': 'user/-/state/com.google/reading-list',
-				'xt': 'user/-/state/com.google/read',
-				'n': 100,
-				'c': continuation
-			}
-			data = urllib.parse.urlencode(var)
-			req = urllib.request.Request(url + '?' + data, data=None, headers=self.header)
-			response = urllib.request.urlopen(req)
-			the_page = response.read()
-			resp = json.loads(the_page.decode("utf-8"))
-			continuation = resp.get('continuation')
-			items_list = items_list + resp['itemRefs']
-		obj_item_list = []
-		for item in items_list:
-			obj_item_list.append(TheOldReaderItem(self.header, item.get('id')))
-		return obj_item_list
+    def get_unread_only(self, limit_items=1000):
+        var = {
+            's': 'user/-/state/com.google/reading-list',
+            'xt': 'user/-/state/com.google/read'
+        }
+        resp = self._make_search_request(var, limit_items)
+        continuation = resp.get('continuation')
+        items_list = resp.get('itemRefs', [])
+        return self._load_rest(continuation, var, limit_items, items_list)
+
+    def get_starred_only(self, limit_items=1000):
+        var = {
+            's': 'user/-/state/com.google/starred'
+        }
+        resp = self._make_search_request(var, limit_items)
+        continuation = resp.get('continuation')
+        items_list = resp.get('itemRefs', [])
+        return self._load_rest(continuation, var, limit_items, items_list)
+
+    def get_liked_only(self, limit_items=1000):
+        var = {
+            's': 'user/-/state/com.google/like'
+        }
+        resp = self._make_search_request(var, limit_items)
+        continuation = resp.get('continuation')
+        items_list = resp.get('itemRefs', [])
+        return self._load_rest(continuation, var, limit_items, items_list)
+
+    def get_shared_only(self, limit_items=1000):
+        var = {
+            's': 'user/-/state/com.google/broadcast'
+        }
+        resp = self._make_search_request(var, limit_items)
+        continuation = resp.get('continuation')
+        items_list = resp.get('itemRefs', [])
+        return self._load_rest(continuation, var, limit_items, items_list)


### PR DESCRIPTION
### Summary

Most of this is code clean up.
The interface is mostly the same. _TheOldReaderItem_ and _TheOldReaderItemsSearch_ take a _TheOldReaderConnection_ object now instead of just the header.
The _get_unread_only_, _get_starred_only_,.. etc. functions now take an optional argument to control how many ids are loaded per request.
### Changes:
- made it pep8 compliant (mostly)
- added a .gitignore file
- removed duplicate code (100+ lines)
- gave Item and ItemsSearch the connection instance rather than only the header
- add limit_items to get_unread_only, get_starred_only, get_liked_only, get_shared_only
- fixed a potential bug, where you might have loaded unread posts instead of starred, liked,...

Let me know what you think!
